### PR TITLE
Abaqus 2020 and up has a different filestructure

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -335,9 +335,9 @@ sudo gedit /usr/SIMULIA/EstProducts/2022/linux_a64/SMA/site/lnx86_64.env
 as follows:
 
 * Change `ifort` to `gfortran` on the `fortCmd` line and make sure that `g++` is on the `cppCmd` line
-* Remove gnu-incompatible compiler flags from the compile_fortran line (-V, -auto, -mP2OPT_hpo_vec_divbyzero=F, -extend_source, -fpp, -WB)
-* link_sl: remove command line options ‘-V’, ‘-cxxlib’, ‘-threads’, ‘-parallel’, ‘-shared-intel’
-* add '-lgfortran' to the link_sl and link_exe lines
+* Remove gnu-incompatible compiler flags from the compile_fortran line (`-V, -auto, -mP2OPT_hpo_vec_divbyzero=F, -extend_source, -fpp, -WB`)
+* link_sl: remove command line options `-V, -cxxlib, -threads, -parallel, -shared-intel`
+* add `-lgfortran` to the `link_sl` and `link_exe` lines
 
 <!--
 How to avoid strange Fox-windows? After each start delete file $HOME/abaqus_2019.gpr?

--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,11 @@
-# Abaqus 2019 on Ubuntu 20.04
+# Abaqus 2020/2022 on Ubuntu 20.04
 
 ## Intro
 
 Ubuntu seems to not be officially supported by the Abaqus installation procedure. This guide shows how to install the necessary libraries and how to tweak the installation files in order to install Abaqus on Ubuntu 20.04. To successfully follow this guide you need writing privileges ('sudo').
 
 *Note:*</br>
-This guide should also work for Abaqus6.14 (changing accordigly file names and paths) and Ubuntu 18.xx adn 19.xx, although I haven't tested it.
+This guide should also work for Abaqus 2021 (changing accordigly file names and paths) and Ubuntu 20.10 till 22.04, although I haven't tested it.
 
 ## Install prerequisites
 
@@ -44,77 +44,113 @@ the installation, locate all the **Linux.sh** files in the Abaqus installation f
 in each of them:
 
 ```sh
-DSY_LIBPATH_VARNAME=LD_LIBRARY_PATH
+  DSY_LIBPATH_VARNAME=LD_LIBRARY_PATH
 
-which lsb_release
-if [[ $? -ne 0 ]] ; then
-  echo "lsb_release is not found: check in the PDIR the list of installed packages for servers validation."
-  exit 12
-fi
+  which lsb_release
+  if [[ $? -ne 0 ]] ; then
+    echo "lsb_release is not found: check in the PDIR the list of installed packages for servers validation."
+    exit 12
+  fi
 
-DSY_OS_Release="CentOS" #Override release setting, old: DSY_OS_Release=`lsb_release --short --id |sed 's/ //g'`
-echo "DSY_OS_Release=\""${DSY_OS_Release}"\""
-export DSY_OS_Release=${DSY_OS_Release}
-export DSY_Skip_CheckPrereq=1 #Added to avoid prerequisite check
+  DSY_OS_Release="CentOS" #Override release setting, old: DSY_OS_Release=`lsb_release --short --id |sed 's/ //g'`
+  echo "DSY_OS_Release=\""${DSY_OS_Release}"\""
+  export DSY_OS_Release=${DSY_OS_Release}
+  export DSY_Skip_CheckPrereq=1 #Added to avoid prerequisite check
 
-if [[ -n ${DSY_Force_OS} ]]; then
-  DSY_OS=${DSY_Force_OS}
-  echo "DSY_Force_OS=\""${DSY_Force_OS}"\", use it for DSY_OS"
-  return
-fi
+  if [[ -n ${DSY_Force_OS} ]]; then
+    DSY_OS=${DSY_Force_OS}
+    echo "DSY_Force_OS=\""${DSY_Force_OS}"\", use it for DSY_OS"
+    return
+  fi
 
-case ${DSY_OS_Release} in
-    "RedHatEnterpriseServer"|"RedHatEnterpriseClient"|"RedHatEnterpriseWorkstation"|"CentOS")
-        DSY_OS=linux_a64;;
-    "SUSELINUX"|"SUSE")
-        DSY_OS=linux_a64;;
-    *)
-        echo "Unknown linux release \""${DSY_OS_Release}"\""
-        echo "exit 8"
-        exit 8;;
-esac
+  case ${DSY_OS_Release} in
+      "RedHatEnterpriseServer"|"RedHatEnterpriseClient"|"RedHatEnterpriseWorkstation"|"CentOS")
+          DSY_OS=linux_a64;;
+      "SUSELINUX"|"SUSE")
+          DSY_OS=linux_a64;;
+      *)
+          echo "Unknown linux release \""${DSY_OS_Release}"\""
+          echo "exit 8"
+          exit 8;;
+  esac
 ```
 
 Note the changes: 1) the release version was forced to be `"CentOS"` , and 2) checking of prerequisites was disabled.
 
 ## Run setup
+The setup of Abaqus requiers a `bash` instead of a `dash` shell, wheras the latter is the default in Ubuntu. To temporary change that we symlink the shell command to `bash` by:
+```dash
+sudo ln -sf bash /bin/sh
+```
+which we'll undo after the instalation.
 
 Once all the prerequisites are installed and the installation files modified, it is possible to proceed with the installation:
-
 ```bash
 cd path_to_abaqus_installation_folder\1
 sudo ./StartGUI.sh
 ```
 
-this will start the installation for all the Abaqus-related products. Skip the installation of the FlexNET server (this will cause an error) and proceed with the installation using the default locations for the software:
-
+this will start the installation for all the Abaqus-related products. Use standard locations for everything.
 ```bash
-/usr/DassaultSystemes/SimulationServices/V6R2019x
-/usr/SIMULIA/CAE/2019
+/usr/SIMULIA/EstProducts/2022
+```
+When it asks for the licence skip it "Skip licensing configuration" (otherwise it will cause an error) and proceed with the installation using the default locations for the software:
+```bash
+/var/DassaultSystemes/SIMULIA/Commands
+/var/DassaultSystemes/SIMULIA/CAE/plugins/2022
 ```
 
-Once the installation is complete you have to setup the FlexNET server. To do so, execute:
- `sudo gedit /usr/DassaultSystemes/SimulationServices/V6R2019x/linux_a64/SMA/site/custom_v6.env`
-
-and then change the license server type to FLEXNET and the abaquslm_license_file to the one of your license (something like ###@your_company_domain), as follows:
-
+Now that the instalation is complete we revert the standard shell back to dash:
 ```bash
-    doc_root="http://help.3ds.com"
-    license_server_type=FLEXNET
-    abaquslm_license_file="27800@your_company_domain"
+sudo ln -sf dash /bin/sh
 ```
+
+## Licence Activation.
+The exact way to setup a licence depends on the type of licence that you have. FlexNET or DSLS.
+
+### FlexNET
+To specify a FlexNET server, execute:
+```sh
+sudo gedit /usr/SIMULIA/EstProducts/2022/linux_a64/SMA/site/custom_v6.env
+```
+
+and then change the license server type to FLEXNET and the abaquslm_license_file to the one of your license
+
+```sh
+# Installation of Established Products 2022
+
+# Day Month date hh:mm:ss yyyy
+  plugin_central_dir="/var/DassaultSystemes/SIMULIA/CAE/plugins/2022"
+  license_server_type=FLEXNET
+  abaquslm_license_file="<port>@<your_domain>"
+```
+where `<port>` is the port used on the licence server, and `<your_domain>` the domain of the licence server.
+
+### DSLS
+To specify a DSLS server, execute:
+```sh
+sudo gedit /var/DassaultSystemes/Licenses/DSLicSrv.txt
+```
+and add to this file the line:
+```sh
+  <your_domain>:<port>
+```
+where `<port>` is the port used on the licence server, and `<your_domain>` the domain of the licence server.
 
 ## Make abaqus command available from any directory
 
-In order to run Abaqus from any location, execute the following comand: `sudo ln /var/DassaultSystemes/SIMULIA/Commands/abq2019 /usr/bin/abaqus`
+In order to run Abaqus from any location, execute the following comand: 
+```sh
+sudo ln /var/DassaultSystemes/SIMULIA/Commands/abq2022 /usr/bin/abaqus`
+```
 
 ## OpenGL Errors
 
 If there is any warning regarding OpenGL in the terminal during start, simply run Abaqus with -mesa parameter:
 
-```bash
-    abaqus cae -mesa
-    abaqus view -mesa
+```sh
+abaqus cae -mesa
+abaqus view -mesa
 ```
 
 ## Shortcuts
@@ -125,17 +161,15 @@ Create shortcut for CAE:
 gedit ~/.local/share/applications/abaquscae.desktop
 ```
 
-```
-    desktop
-    [Desktop Entry]
-    Type=Application
-    Version=1.0
-    Name[en_US]=abaquscae
-    Icon=/opt/SIMULIA/CAE/2019/linux_a64/CAEresources/graphic/icons/icoR_application.png
-    Exec=sh -c "export FILE=%u && cd $(dirname $FILE) && abaqus cae database=$FILE -mesa"
-    # Exec=abaqus cae database=%u -mesa
-    Terminal=true
-    Categories=Science;
+```sh
+  [Desktop Entry]
+  Type=Application
+  Version=1.0
+  Name=Abaqus Viewer
+  Icon=/usr/SIMULIA/EstProducts/2022/linux_a64/CAEresources/graphic/icons/icoR_application.png
+  Exec=sh -c "export FILE=%u && cd $(dirname $FILE) && abaqus viewer database=$FILE -mesa"
+  Terminal=true
+  Categories=Science;
 ```
 
 Create shortcut for Viewer:
@@ -145,16 +179,14 @@ gedit ~/.local/share/applications/abaqusviewer.desktop
 ```
 
 ```sh
-    desktop
-    [Desktop Entry]
-    Type=Application
-    Version=1.0
-    Name[en_US]=abaqusviewer
-    Icon=/opt/SIMULIA/CAE/2019/linux_a64/CAEresources/graphic/icons/icoR_application.png
-    Exec=sh -c "export FILE=%u && cd $(dirname $FILE) && abaqus viewer database=$FILE -mesa"
-    # Exec=abaqus view database=%u -mesa
-    Terminal=true
-    Categories=Science;
+  [Desktop Entry]
+  Type=Application
+  Version=1.0
+  Name=Abaqus Viewer
+  Icon=/usr/SIMULIA/EstProducts/2022/linux_a64/CAEresources/graphic/icons/icoR_application.png
+  Exec=sh -c "export FILE=%u && cd $(dirname $FILE) && abaqus viewer database=$FILE -mesa"
+  Terminal=true
+  Categories=Science;
 ```
 
 Then make *.desktop executable:  
@@ -171,8 +203,9 @@ sudo gedit /usr/share/mime/packages/libreoffice.xml
 and comment tag:
 
 ```xml
-    <mime-type type="application/vnd.sun.xml.base">
+  <mime-type type="application/vnd.sun.xml.base">
 ```
+by adding `<!--` at the start of that line and `-->` after the next </mime-type> that you find.
 
 Add Abaqus mime types:
 
@@ -183,46 +216,46 @@ sudo gedit ~/.mime.types
 Add lines:
 
 ```sh
-    application/abaquscae				cae
-    application/abaqusviewer			odb
+  application/abaquscae				cae
+  application/abaqusviewer			odb
 ```
 
 Create file:
 
 ```sh
-    sudo gedit /usr/share/mime/packages/abaquscae.xml
+sudo gedit /usr/share/mime/packages/abaquscae.xml
 ```
 
 ```xml
-    <?xml version="1.0" encoding="UTF-8"?>
-    <mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
-        <mime-type type="application/abaquscae">
-            <comment>Abaqus CAE</comment>
-            <glob pattern="*.cae"/>
-        </mime-type>
-    </mime-info>
+  <?xml version="1.0" encoding="UTF-8"?>
+  <mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+      <mime-type type="application/abaquscae">
+          <comment>Abaqus CAE</comment>
+          <glob pattern="*.cae"/>
+      </mime-type>
+  </mime-info>
 ```
 
 Create file:
 
 ```sh
-    sudo gedit /usr/share/mime/packages/abaqusviewer.xml
+sudo gedit /usr/share/mime/packages/abaqusviewer.xml
 ```
 
 ```xml
-    <?xml version="1.0" encoding="UTF-8"?>
-    <mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
-        <mime-type type="application/abaqusviewer">
-            <comment>Abaqus Viewer</comment>
-            <glob pattern="*.odb"/>
-        </mime-type>
-    </mime-info>
+  <?xml version="1.0" encoding="UTF-8"?>
+  <mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+      <mime-type type="application/abaqusviewer">
+          <comment>Abaqus Viewer</comment>
+          <glob pattern="*.odb"/>
+      </mime-type>
+  </mime-info>
 ```
 
 Then update MIME database:
 
 ```sh
-    sudo update-mime-database /usr/share/mime
+sudo update-mime-database /usr/share/mime
 ```
 
 Additionally install "MIME Type Editor" via software and edit file associations.
@@ -240,7 +273,7 @@ Create icons for Abaqus file types:
 Open Abaqus CAE and check if it uses *Courier-New* and *Verdana* fonts:
 
 ```sh
-    lsof -c ABQcaeK | grep fonts
+lsof -c ABQcaeK | grep fonts
 ```
 
 Increase font size: <https://kb.dsxclient.3ds.com/mashup-ui/page/resultqa?id=QA00000008675e>
@@ -259,11 +292,10 @@ Install MS core fonts and RESTART:
 
 -->
 
-Edit dictionaries:
+I didn't get the follwing font size increase working, I only found the file `EstProducts` file and nothing such as `/opt/SIMULIA` or `opt/DassaultSystems`. I expected that the following file would do the trick, but it doesn't:
 
 ```sh
-    /opt/SIMULIA/CAE/2019/linux_a64/SMA/Configuration/Xresources/en_US/en_US_Dict.py
-    /opt/DassaultSystemes/SimulationServices/V6R2019x/linux_a64/SMA/Configuration/Xresources/en_US/en_US_Dict.py
+sudo gedit /usr/SIMULIA/EstProducts/2022/linux_a64/SMA/Configuration/Xresources/en_US/en_US_Dict.py
 ```
 
 and increase font size:
@@ -280,12 +312,12 @@ and increase font size:
 For big displays font HELVETICA and sizes 17-20-25 are more appropriate:
 
 ```python
-    masterDict[r'-*-courier-<weight>-<slant>-normal--10-*'] = r'-*-helvetica-<weight>-<slant>-normal--17-*'
-    masterDict[r'-*-courier-<weight>-<slant>-normal--12-*'] = r'-*-helvetica-<weight>-<slant>-normal--20-*'
-    masterDict[r'-*-courier-<weight>-<slant>-normal--14-*'] = r'-*-helvetica-<weight>-<slant>-normal--25-*'
-    masterDict[r'-*-helvetica-<weight>-<slant>-normal--10-*'] = r'-*-helvetica-<weight>-<slant>-normal--17-*'
-    masterDict[r'-*-helvetica-<weight>-<slant>-normal--12-*'] = r'-*-helvetica-<weight>-<slant>-normal--20-*'
-    masterDict[r'-*-helvetica-<weight>-<slant>-normal--14-*'] = r'-*-helvetica-<weight>-<slant>-normal--25-*'
+  masterDict[r'-*-courier-<weight>-<slant>-normal--10-*'] = r'-*-helvetica-<weight>-<slant>-normal--17-*'
+  masterDict[r'-*-courier-<weight>-<slant>-normal--12-*'] = r'-*-helvetica-<weight>-<slant>-normal--20-*'
+  masterDict[r'-*-courier-<weight>-<slant>-normal--14-*'] = r'-*-helvetica-<weight>-<slant>-normal--25-*'
+  masterDict[r'-*-helvetica-<weight>-<slant>-normal--10-*'] = r'-*-helvetica-<weight>-<slant>-normal--17-*'
+  masterDict[r'-*-helvetica-<weight>-<slant>-normal--12-*'] = r'-*-helvetica-<weight>-<slant>-normal--20-*'
+  masterDict[r'-*-helvetica-<weight>-<slant>-normal--14-*'] = r'-*-helvetica-<weight>-<slant>-normal--25-*'
 ```
 
 <!--
@@ -295,11 +327,14 @@ For big displays font HELVETICA and sizes 17-20-25 are more appropriate:
 
 ## FORTRAN
 
-To use *gfortran* edit: `/opt/DassaultSystemes/SimulationServices/V6R2019x/linux_a64/SMA/site/lnx86_64.env`
+To use *gfortran* edit: 
+```sh
+sudo gedit /usr/SIMULIA/EstProducts/2022/linux_a64/SMA/site/lnx86_64.env
+```
 
 as follows:
 
-* Change ifort to gfortran on the fortCmd line and make sure that g++ is on the cppCmd line
+* Change `ifort` to `gfortran` on the `fortCmd` line and make sure that `g++` is on the `cppCmd` line
 * Remove gnu-incompatible compiler flags from the compile_fortran line (-V, -auto, -mP2OPT_hpo_vec_divbyzero=F, -extend_source, -fpp, -WB)
 * link_sl: remove command line options ‘-V’, ‘-cxxlib’, ‘-threads’, ‘-parallel’, ‘-shared-intel’
 * add '-lgfortran' to the link_sl and link_exe lines
@@ -309,21 +344,6 @@ How to avoid strange Fox-windows? After each start delete file $HOME/abaqus_2019
 -->
 
 ## KWON ISSUES AND POSSIBLE SOLUTIONS
-
-### Run bash and not dash
-
-If you get an error starting like:
-
-```bash
-`./StartGUI.sh: 4: typeset: not found CurrentMediaDir initial="" ./StartGUI.sh: 6: typeset: not found ./StartGUI.sh: 8: [[: not found ./StartGUI.sh: 10: [[: not found
-...
-```
-
-Check that you run bash and not dash (dash is default in Ubuntu, and the Abaqus Installation script uses bash-specific commands).
-
-One way is to search as root (or via sudo) for `/usr/bin/sh` and make it a symlink to `/usr/bin/bash` .
-
-You should not forget to re-link `/usr/bin/sh` to dash after the Abaqus installation.
 
 ### License Validation
 
@@ -337,5 +357,7 @@ LANG=en_US.utf8 abaqus cae -mesa
 
 This guide is based on:
 
+* <https://github.com/franaudo/abaqus-ubuntu>
+* <https://gist.github.com/cmaurini/60fab556ba4a43bd44341a1af114dde7>
 * <https://github.com/Kevin-Mattheus-Moerman/Abaqus-Installation-Instructions-for-Ubuntu>
 * <https://github.com/imirzov/Install-Abaqus-2019-on-Ubuntu-18.04-LTS>

--- a/readme.md
+++ b/readme.md
@@ -5,11 +5,11 @@
 Ubuntu seems to not be officially supported by the Abaqus installation procedure. This guide shows how to install the necessary libraries and how to tweak the installation files in order to install Abaqus on Ubuntu 20.04. To successfully follow this guide you need writing privileges ('sudo').
 
 *Note:*</br>
-This guide should also work for Abaqus 2021 (changing accordigly file names and paths) and Ubuntu 20.10 till 22.04, although I haven't tested it.
+This guide should also work for Abaqus 2021 (changing accordingly file names and paths) and Ubuntu 20.10 till 22.04, although I haven't tested it.
 
 ## Install prerequisites
 
-The standart Ubuntu release might not have one or more of the following libraries needed by Abaqus:
+The standard Ubuntu release might not have one or more of the following libraries needed by Abaqus:
 
 * libjpeg
 * libstdc++ 4.7
@@ -21,7 +21,7 @@ The standart Ubuntu release might not have one or more of the following librarie
 * lsb-release-2.0
 * libpng12-0
 
-To install them open a terminal and execute the following commmand:
+To install them open a terminal and execute the following command:
 
 ```bash
 sudo apt update
@@ -75,38 +75,38 @@ in each of them:
   esac
 ```
 
-Note the changes: 1) the release version was forced to be `"CentOS"` , and 2) checking of prerequisites was disabled.
+Note the changes: 1) the release version was forced to be `"CentOS"`, and 2) checking for prerequisites was disabled.
 
 ## Run setup
-The setup of Abaqus requiers a `bash` instead of a `dash` shell, wheras the latter is the default in Ubuntu. To temporary change that we symlink the shell command to `bash` by:
+The setup of Abaqus requires a `bash` instead of a `dash` shell, whereas the latter is the default in Ubuntu. To temporary change that we symlink the shell command to `bash` by:
 ```dash
 sudo ln -sf bash /bin/sh
 ```
-which we'll undo after the instalation.
+which we'll undo after the installation.
 
 Once all the prerequisites are installed and the installation files modified, it is possible to proceed with the installation:
 ```bash
-cd path_to_abaqus_installation_folder\1
+cd path_to_abaqus_installation_folder/1
 sudo ./StartGUI.sh
 ```
 
-this will start the installation for all the Abaqus-related products. Use standard locations for everything.
+this will start the installation for all the Abaqus related products. Use standard locations for everything.
 ```bash
 /usr/SIMULIA/EstProducts/2022
 ```
-When it asks for the licence skip it "Skip licensing configuration" (otherwise it will cause an error) and proceed with the installation using the default locations for the software:
+When it asks for the license skip it "Skip licensing configuration" (otherwise it will cause an error) and proceed with the installation using the default locations for the software:
 ```bash
 /var/DassaultSystemes/SIMULIA/Commands
 /var/DassaultSystemes/SIMULIA/CAE/plugins/2022
 ```
 
-Now that the instalation is complete we revert the standard shell back to dash:
+Now that the installation is complete we revert the standard shell back to dash:
 ```bash
 sudo ln -sf dash /bin/sh
 ```
 
-## Licence Activation.
-The exact way to setup a licence depends on the type of licence that you have. FlexNET or DSLS.
+## License Activation.
+The exact way to setup a license depends on the type of license that you have. FlexNET or DSLS.
 
 ### FlexNET
 To specify a FlexNET server, execute:
@@ -124,7 +124,7 @@ and then change the license server type to FLEXNET and the abaquslm_license_file
   license_server_type=FLEXNET
   abaquslm_license_file="<port>@<your_domain>"
 ```
-where `<port>` is the port used on the licence server, and `<your_domain>` the domain of the licence server.
+where `<port>` is the port used on the license server, and `<your_domain>` the domain of the license server.
 
 ### DSLS
 To specify a DSLS server, execute:
@@ -135,11 +135,11 @@ and add to this file the line:
 ```sh
   <your_domain>:<port>
 ```
-where `<port>` is the port used on the licence server, and `<your_domain>` the domain of the licence server.
+where `<port>` is the port used on the license server, and `<your_domain>` the domain of the license server.
 
 ## Make abaqus command available from any directory
 
-In order to run Abaqus from any location, execute the following comand: 
+In order to run Abaqus from any location, execute the following command: 
 ```sh
 sudo ln /var/DassaultSystemes/SIMULIA/Commands/abq2022 /usr/bin/abaqus`
 ```
@@ -192,7 +192,7 @@ gedit ~/.local/share/applications/abaqusviewer.desktop
 Then make *.desktop executable:  
 *Properties-->Permissions-->Allow executing file as program*.
 
-## MIMETYPES & ICONS
+## MIME-TYPES & ICONS
 
 Delete LibreOffice mime type for ODB:
 
@@ -292,7 +292,7 @@ Install MS core fonts and RESTART:
 
 -->
 
-I didn't get the follwing font size increase working, I only found the file `EstProducts` file and nothing such as `/opt/SIMULIA` or `opt/DassaultSystems`. I expected that the following file would do the trick, but it doesn't:
+I didn't get the following font size increase working, I only found the file `EstProducts` file and nothing such as `/opt/SIMULIA` or `opt/DassaultSystems`. I expected that the following file would do the trick, but it doesn't:
 
 ```sh
 sudo gedit /usr/SIMULIA/EstProducts/2022/linux_a64/SMA/Configuration/Xresources/en_US/en_US_Dict.py
@@ -343,7 +343,7 @@ as follows:
 How to avoid strange Fox-windows? After each start delete file $HOME/abaqus_2019.gpr?
 -->
 
-## KWON ISSUES AND POSSIBLE SOLUTIONS
+## KNOWN ISSUES AND POSSIBLE SOLUTIONS
 
 ### License Validation
 


### PR DESCRIPTION
The pull request consists of three commits and :
1. Changing file paths accordingly to the changes made by Abaqus.
2. Include an explanation for both FlexNET and DSLS (thanks to [cmaurini]( https://gist.github.com/cmaurini/60fab556ba4a43bd44341a1af114dde7)) untested.

Note: The changes are not backwards compatible, it must be made clear that these steps are for the 2020+ versions. And the older manual needs to be available for older Abaqus installers.

Known issues:
1. The font size change is not working.

Tested with:
- Ubuntu 20.04
- Abaqus 2020 and 2022 (no reason to believe that 2021 woudn't work)